### PR TITLE
remove dialog icon from js to css

### DIFF
--- a/dialogs/dialogs.css
+++ b/dialogs/dialogs.css
@@ -1,0 +1,6 @@
+.priority .icon {background:url(../dialogs/icons/iconpriority.png) 0 0}
+.progress .icon{background:url(../dialogs/icons/iconprogress.png) 0 0}
+.icon.p2{background-position: -20px 0}
+.icon.p3{background-position: -40px 0}
+.icon.p4{background-position: -60px 0}
+.icon.p5{background-position: -80px 0}

--- a/dialogs/markers/markers.js
+++ b/dialogs/markers/markers.js
@@ -1,19 +1,19 @@
 ( function () {
     var utils = KM.utils;
     KM.registerWidget( 'markers', {
-        tpl: "<ul class='icon-list'>" +
-            "<li value='1' type='priority'><span class='icon' style='background:url(../dialogs/icons/iconpriority.png) 0 0'></span><span><%= priority %>1</span></li>" +
-            "<li value='2' type='priority'><span class='icon' style='background:url(../dialogs/icons/iconpriority.png) -20px 0'></span><span><%= priority %>2</span></li>" +
-            "<li value='3' type='priority'><span class='icon' style='background:url(../dialogs/icons/iconpriority.png) -40px 0'></span><span><%= priority %>3</span></li>" +
-            "<li value='4' type='priority'><span class='icon' style='background:url(../dialogs/icons/iconpriority.png) -60px 0'></span><span><%= priority %>4</span></li>" +
-            "<li value='5' type='priority'><span class='icon' style='background:url(../dialogs/icons/iconpriority.png) -80px 0'></span><span><%= priority %>5</span></li>" +
+        tpl: "<ul class='icon-list priority'>" +
+            "<li value='1' type='priority'><span class='icon p1'></span><span><%= priority %>1</span></li>" +
+            "<li value='2' type='priority'><span class='icon p2'></span><span><%= priority %>2</span></li>" +
+            "<li value='3' type='priority'><span class='icon p3'></span><span><%= priority %>3</span></li>" +
+            "<li value='4' type='priority'><span class='icon p4'></span><span><%= priority %>4</span></li>" +
+            "<li value='5' type='priority'><span class='icon p5'></span><span><%= priority %>5</span></li>" +
             "</ul>" +
-            "<ul class='icon-list'>" +
-            "<li value='1' type='progress'><span class='icon' style='background:url(../dialogs/icons/iconprogress.png) 0 0'></span><span><%= progress.notdone %></span></li>" +
-            "<li value='2' type='progress'><span class='icon' style='background:url(../dialogs/icons/iconprogress.png) -20px 0'></span><span><%= progress.quarterdone %></span></li>" +
-            "<li value='3' type='progress'><span class='icon' style='background:url(../dialogs/icons/iconprogress.png) -40px 0'></span><span><%= progress.halfdone %></span></li>" +
-            "<li value='4' type='progress'><span class='icon' style='background:url(../dialogs/icons/iconprogress.png) -60px 0'></span><span><%= progress.threequartersdone %></span></li>" +
-            "<li value='5' type='progress'><span class='icon' style='background:url(../dialogs/icons/iconprogress.png) -80px 0'></span><span><%= progress.done %></span></li>" +
+            "<ul class='icon-list progress'>" +
+            "<li value='1' type='progress'><span class='icon p1'></span><span><%= progress.notdone %></span></li>" +
+            "<li value='2' type='progress'><span class='icon p2'></span><span><%= progress.quarterdone %></span></li>" +
+            "<li value='3' type='progress'><span class='icon p3'></span><span><%= progress.halfdone %></span></li>" +
+            "<li value='4' type='progress'><span class='icon p4'></span><span><%= progress.threequartersdone %></span></li>" +
+            "<li value='5' type='progress'><span class='icon p5'></span><span><%= progress.done %></span></li>" +
             "</ul>",
         initContent: function ( km ) {
             var lang = km.getLang( 'dialogs.markers' );

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,6 +12,7 @@
     <script src="../lang/zh-cn/zh-cn.js" charset="utf-8"></script>
     <link href="../themes/default/css/import.css" type="text/css" rel="stylesheet">
     <link rel="stylesheet" href="social.css">
+    <link rel="stylesheet" type="text/css" href="../dialogs/dialogs.css">
     <style>
         .km_receiver{
             width:0;


### PR DESCRIPTION
Using background image and style in JavaScript and HTML is not good. This change removed dialog icon from JavaScript to CSS
