### PR TITLE
Revert "Add random colors for the 9th and latter labels"

### DIFF
--- a/src/module/resource.js
+++ b/src/module/resource.js
@@ -34,8 +34,8 @@ KityMinder.registerModule('Resource', function() {
                 colorMapping[resource] = nextIndex;
             }
 
-            // 资源过多，找不到可用索引颜色时，返回随机颜色
-            return RESOURCE_COLOR_SERIES[colorMapping[resource]] || kity.Color.createHSL(Math.floor(Math.random() * 256), 100, 85);
+            // 资源过多，找不到可用索引颜色，统一返回白色
+            return RESOURCE_COLOR_SERIES[colorMapping[resource]] || RESOURCE_COLOR_OVERFLOW;
         },
 
         /**


### PR DESCRIPTION
Reverts fex-team/kityminder#223

原因：
1. 生成的颜色不能稳定渲染，每次渲染后颜色发生改变。
2. 最好有一种能区别其它颜色的机制
